### PR TITLE
Uplift Go version to 1.24.0

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -15,6 +15,8 @@ jobs:
 
       - name: 🔰 Set up Go ...
         uses: actions/setup-go@v4
+        with:
+          go-version: '1.24.0'
 
       - name: 🧪 Testing ...
         run: make audit


### PR DESCRIPTION
Uplift Go in CI jobs to follow requirements.

(MINOR)